### PR TITLE
fix katutil path

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3
 WORKDIR /usr/src/app
 
 COPY cli cli
-COPY python-sdk python-sdk
+COPY python-identity-sdk python-identity-sdk
 RUN cd cli && pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /usr/src/app/cli

--- a/cli/katutil.py
+++ b/cli/katutil.py
@@ -3,7 +3,7 @@ import logging as log
 import core_utils
 import argparse
 import json
-import katanemo_sdk
+import katanemo_identity as katanemo_sdk
 
 log.basicConfig(level=log.INFO, format="%(message)s")
 


### PR DESCRIPTION
fixes following error,
```
(.venv) ➜  cli git:(main) ✗ bin/katutil
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/app/cli/katutil.py", line 6, in <module>
    import katanemo_sdk
ModuleNotFoundError: No module named 'katanemo_sdk'
```